### PR TITLE
GridFS support

### DIFF
--- a/aiomongo/__init__.py
+++ b/aiomongo/__init__.py
@@ -5,6 +5,7 @@ from .client import AioMongoClient
 from .collection import Collection
 from .connection import Connection
 from .database import Database
+from .gridfs import GridFS
 
 
 async def create_client(uri: str, loop: Optional[asyncio.AbstractEventLoop] = None) -> AioMongoClient:
@@ -16,4 +17,4 @@ async def create_client(uri: str, loop: Optional[asyncio.AbstractEventLoop] = No
 
     return cl
 
-__all__ = ['AioMongoClient', 'Collection', 'Connection', 'Database']
+__all__ = ['AioMongoClient', 'Collection', 'Connection', 'Database', 'GridFS']

--- a/aiomongo/grid_file.py
+++ b/aiomongo/grid_file.py
@@ -197,7 +197,7 @@ class GridIn:
             await self.__flush()
             object.__setattr__(self, '_closed', True)
 
-    def write(self, data):
+    async def write(self, data):
         """Write data to the file. There is no return value.
 
         `data` can be either a string of bytes or a file-like object
@@ -249,20 +249,20 @@ class GridIn:
                 self._buffer.write(to_write)
                 if len(to_write) < space:
                     return  # EOF or incomplete
-            self.__flush_buffer()
+            await self.__flush_buffer()
         to_write = read(self.chunk_size)
         while to_write and len(to_write) == self.chunk_size:
-            self.__flush_data(to_write)
+            await self.__flush_data(to_write)
             to_write = read(self.chunk_size)
         self._buffer.write(to_write)
 
-    def writelines(self, sequence):
+    async def writelines(self, sequence):
         """Write a sequence of strings to the file.
 
         Does not add seperators.
         """
         for line in sequence:
-            self.write(line)
+            await self.write(line)
 
     def __enter__(self):
         """Support for the context manager protocol.

--- a/aiomongo/grid_file.py
+++ b/aiomongo/grid_file.py
@@ -7,7 +7,7 @@ from typing import BinaryIO, List, Union
 
 from bson import ObjectId
 from bson.binary import Binary
-from gridfs.errors import CorruptGridFile, NoFile
+from gridfs.errors import CorruptGridFile, FileExists, NoFile
 from gridfs.grid_file import _C_INDEX, _F_INDEX, DEFAULT_CHUNK_SIZE, EMPTY, NEWLN
 from pymongo import ReadPreference
 from pymongo.errors import ConfigurationError, DuplicateKeyError, OperationFailure

--- a/aiomongo/grid_file.py
+++ b/aiomongo/grid_file.py
@@ -3,6 +3,7 @@ import math
 from hashlib import md5
 from io import BytesIO
 from os import SEEK_SET, SEEK_CUR, SEEK_END
+from typing import BinaryIO, List, Union
 
 from bson import ObjectId
 from bson.binary import Binary
@@ -197,7 +198,7 @@ class GridIn:
             await self.__flush()
             object.__setattr__(self, '_closed', True)
 
-    async def write(self, data):
+    async def write(self, data: Union[bytes, str, BinaryIO]) -> None:
         """Write data to the file. There is no return value.
 
         `data` can be either a string of bytes or a file-like object
@@ -256,7 +257,7 @@ class GridIn:
             to_write = read(self.chunk_size)
         self._buffer.write(to_write)
 
-    async def writelines(self, sequence):
+    async def writelines(self, sequence: List[Union[bytes, str]]) -> None:
         """Write a sequence of strings to the file.
 
         Does not add seperators.

--- a/aiomongo/grid_file.py
+++ b/aiomongo/grid_file.py
@@ -6,8 +6,8 @@ from os import SEEK_SET, SEEK_CUR, SEEK_END
 
 from bson import ObjectId
 from bson.binary import Binary
-from gridfs.errors import NoFile
-from gridfs.grid_file import _C_INDEX, _F_INDEX, DEFAULT_CHUNK_SIZE, EMPTY
+from gridfs.errors import CorruptGridFile, NoFile
+from gridfs.grid_file import _C_INDEX, _F_INDEX, DEFAULT_CHUNK_SIZE, EMPTY, NEWLN
 from pymongo import ReadPreference
 from pymongo.errors import ConfigurationError, DuplicateKeyError, OperationFailure
 
@@ -396,7 +396,7 @@ class GridOut:
         data.seek(0)
         return data.read(size)
 
-    def readline(self, size=-1):
+    async def readline(self, size=-1):
         """Read one line or up to `size` bytes from the file.
 
         :Parameters:
@@ -410,9 +410,9 @@ class GridOut:
             size = remainder
 
         received = 0
-        data = StringIO()
+        data = BytesIO()
         while received < size:
-            chunk_data = self.readchunk()
+            chunk_data = await self.readchunk()
             pos = chunk_data.find(NEWLN, 0, size)
             if pos != -1:
                 size = received + pos + 1

--- a/aiomongo/grid_file.py
+++ b/aiomongo/grid_file.py
@@ -1,0 +1,513 @@
+import datetime
+import math
+from hashlib import md5
+from io import BytesIO
+from os import SEEK_SET, SEEK_CUR, SEEK_END
+
+from bson import ObjectId
+from bson.binary import Binary
+from gridfs.errors import NoFile
+from gridfs.grid_file import _C_INDEX, _F_INDEX, DEFAULT_CHUNK_SIZE, EMPTY
+from pymongo import ReadPreference
+from pymongo.errors import ConfigurationError, DuplicateKeyError, OperationFailure
+
+
+def _grid_in_property(field_name, docstring, read_only=False,
+                      closed_only=False):
+    """Create a GridIn property."""
+    def getter(self):
+        if closed_only and not self._closed:
+            raise AttributeError('can only get %r on a closed file' %
+                                 field_name)
+        # Protect against PHP-237
+        if field_name == 'length':
+            return self._file.get(field_name, 0)
+        return self._file.get(field_name, None)
+
+    def setter(self, value):
+        if self._closed:
+            raise AttributeError('can only set %r on a unclosed file' %
+                                 field_name)
+        self._file[field_name] = value
+
+    if read_only:
+        docstring += '\n\nThis attribute is read-only.'
+    elif closed_only:
+        docstring = '%s\n\n%s' % (docstring, 'This attribute is read-only and '
+                                             'can only be read after :meth:`close` '
+                                             'has been called.')
+
+    if not read_only and not closed_only:
+        return property(getter, setter, doc=docstring)
+    return property(getter, doc=docstring)
+
+
+class GridIn:
+    def __init__(self, root_collection: 'aiomongo.Collection', **kwargs):
+        # With w=0, 'filemd5' might run before the final chunks are written.
+        if not root_collection.write_concern.acknowledged:
+            raise ConfigurationError('root_collection must use '
+                                     'acknowledged write_concern')
+
+        # Handle alternative naming
+        if 'content_type' in kwargs:
+            kwargs['contentType'] = kwargs.pop('content_type')
+        if 'chunk_size' in kwargs:
+            kwargs['chunkSize'] = kwargs.pop('chunk_size')
+
+        coll = root_collection.with_options(
+            read_preference=ReadPreference.PRIMARY)
+
+        kwargs['md5'] = md5()
+        # Defaults
+        kwargs['_id'] = kwargs.get('_id', ObjectId())
+        kwargs['chunkSize'] = kwargs.get('chunkSize', DEFAULT_CHUNK_SIZE)
+        object.__setattr__(self, '_coll', coll)
+        object.__setattr__(self, '_chunks', coll.chunks)
+        object.__setattr__(self, '_file', kwargs)
+        object.__setattr__(self, '_buffer', BytesIO())
+        object.__setattr__(self, '_position', 0)
+        object.__setattr__(self, '_chunk_number', 0)
+        object.__setattr__(self, '_closed', False)
+        object.__setattr__(self, '_ensured_index', False)
+
+    async def __create_index(self, collection, index, unique):
+        doc = await collection.find_one(projection={'_id': 1})
+        if doc is None:
+            indexes = list()
+            try:
+                async with await collection.list_indexes() as cursor:
+                    async for index in cursor:
+                        indexes.append(index)
+            except OperationFailure:
+                pass
+            if index not in indexes:
+                await collection.create_index(index, unique=unique)
+
+    async def __ensure_indexes(self):
+        if not object.__getattribute__(self, '_ensured_index'):
+            await self.__create_index(self._coll.files, _F_INDEX, False)
+            await self.__create_index(self._coll.chunks, _C_INDEX, True)
+            object.__setattr__(self, '_ensured_index', True)
+
+    def abort(self):
+        """Remove all chunks/files that may have been uploaded and close.
+        """
+        self._coll.chunks.delete_many({'files_id': self._file['_id']})
+        self._coll.files.delete_one({'_id': self._file['_id']})
+        object.__setattr__(self, '_closed', True)
+
+
+    @property
+    def closed(self):
+        """Is this file closed?
+        """
+        return self._closed
+
+    _id = _grid_in_property('_id', "The ``'_id'`` value for this file.",
+                            read_only=True)
+    filename = _grid_in_property('filename', 'Name of this file.')
+    name = _grid_in_property('filename', 'Alias for `filename`.')
+    content_type = _grid_in_property('contentType', 'Mime-type for this file.')
+    length = _grid_in_property('length', 'Length (in bytes) of this file.',
+                               closed_only=True)
+    chunk_size = _grid_in_property('chunkSize', 'Chunk size for this file.',
+                                   read_only=True)
+    upload_date = _grid_in_property('uploadDate',
+                                    'Date that this file was uploaded.',
+                                    closed_only=True)
+    md5 = _grid_in_property('md5', 'MD5 of the contents of this file '
+                            '(generated on the server).',
+                            closed_only=True)
+
+    def __getattr__(self, name):
+        if name in self._file:
+            return self._file[name]
+        raise AttributeError("GridIn object has no attribute '%s'" % name)
+
+    def __setattr__(self, name, value):
+        # For properties of this instance like _buffer, or descriptors set on
+        # the class like filename, use regular __setattr__
+        if name in self.__dict__ or name in self.__class__.__dict__:
+            object.__setattr__(self, name, value)
+        else:
+            # All other attributes are part of the document in db.fs.files.
+            # Store them to be sent to server on close() or if closed, send
+            # them now.
+            self._file[name] = value
+            if self._closed:
+                self._coll.files.update_one({'_id': self._file['_id']},
+                                            {'$set': {name: value}})
+
+    async def __flush_data(self, data):
+        """Flush `data` to a chunk.
+        """
+        # Ensure the index, even if there's nothing to write, so
+        # the filemd5 command always succeeds.
+        await self.__ensure_indexes()
+        self._file['md5'].update(data)
+
+        if not data:
+            return
+        assert(len(data) <= self.chunk_size)
+
+        chunk = {'files_id': self._file['_id'],
+                 'n': self._chunk_number,
+                 'data': Binary(data)}
+
+        try:
+            await self._chunks.insert_one(chunk)
+        except DuplicateKeyError:
+            self._raise_file_exists(self._file['_id'])
+        self._chunk_number += 1
+        self._position += len(data)
+
+    async def __flush_buffer(self):
+        """Flush the buffer contents out to a chunk.
+        """
+        await self.__flush_data(self._buffer.getvalue())
+        self._buffer.close()
+        self._buffer = BytesIO()
+
+    async def __flush(self):
+        """Flush the file to the database.
+        """
+        try:
+            await self.__flush_buffer()
+
+            self._file['md5'] = self._file['md5'].hexdigest()
+            self._file['length'] = self._position
+            self._file['uploadDate'] = datetime.datetime.utcnow()
+
+            return await self._coll.files.insert_one(self._file)
+        except DuplicateKeyError:
+            self._raise_file_exists(self._id)
+
+    def _raise_file_exists(self, file_id):
+        """Raise a FileExists exception for the given file_id."""
+        raise FileExists('file with _id %r already exists' % file_id)
+
+    async def close(self):
+        """Flush the file and close it.
+
+        A closed file cannot be written any more. Calling
+        :meth:`close` more than once is allowed.
+        """
+        if not self._closed:
+            await self.__flush()
+            object.__setattr__(self, '_closed', True)
+
+    def write(self, data):
+        """Write data to the file. There is no return value.
+
+        `data` can be either a string of bytes or a file-like object
+        (implementing :meth:`read`). If the file has an
+        :attr:`encoding` attribute, `data` can also be a
+        :class:`unicode` (:class:`str` in python 3) instance, which
+        will be encoded as :attr:`encoding` before being written.
+
+        Due to buffering, the data may not actually be written to the
+        database until the :meth:`close` method is called. Raises
+        :class:`ValueError` if this file is already closed. Raises
+        :class:`TypeError` if `data` is not an instance of
+        :class:`str` (:class:`bytes` in python 3), a file-like object,
+        or an instance of :class:`unicode` (:class:`str` in python 3).
+        Unicode data is only allowed if the file has an :attr:`encoding`
+        attribute.
+
+        :Parameters:
+          - `data`: string of bytes or file-like object to be written
+            to the file
+        """
+        if self._closed:
+            raise ValueError('cannot write to a closed file')
+
+        try:
+            # file-like
+            read = data.read
+        except AttributeError:
+            # string
+            if not isinstance(data, (str, bytes)):
+                raise TypeError('can only write strings or file-like objects')
+            if isinstance(data, str):
+                try:
+                    data = data.encode(self.encoding)
+                except AttributeError:
+                    raise TypeError('must specify an encoding for file in '
+                                    'order to write %s' % (str.__name__,))
+            read = BytesIO(data).read
+
+        if self._buffer.tell() > 0:
+            # Make sure to flush only when _buffer is complete
+            space = self.chunk_size - self._buffer.tell()
+            if space:
+                try:
+                    to_write = read(space)
+                except:
+                    self.abort()
+                    raise
+                self._buffer.write(to_write)
+                if len(to_write) < space:
+                    return  # EOF or incomplete
+            self.__flush_buffer()
+        to_write = read(self.chunk_size)
+        while to_write and len(to_write) == self.chunk_size:
+            self.__flush_data(to_write)
+            to_write = read(self.chunk_size)
+        self._buffer.write(to_write)
+
+    def writelines(self, sequence):
+        """Write a sequence of strings to the file.
+
+        Does not add seperators.
+        """
+        for line in sequence:
+            self.write(line)
+
+    def __enter__(self):
+        """Support for the context manager protocol.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Support for the context manager protocol.
+
+        Close the file and allow exceptions to propagate.
+        """
+        self.close()
+
+        # propagate exceptions
+        return False
+
+
+def _grid_out_property(field_name, docstring):
+    """Create a GridOut property."""
+    def getter(self):
+        # Protect against PHP-237
+        if field_name == 'length':
+            return self._file.get(field_name, 0)
+        return self._file.get(field_name, None)
+
+    docstring += '\n\nThis attribute is read-only.'
+    return property(getter, doc=docstring)
+
+
+class GridOut:
+    def __init__(self, root_collection: 'aiomongo.Collection', file_id=None, file_document=None):
+        self.__chunks = root_collection.chunks
+        self.__files = root_collection.files
+        self.__file_id = file_id
+        self.__buffer = EMPTY
+        self.__position = 0
+        self._file = file_document
+
+    _id = _grid_out_property('_id', "The ``'_id'`` value for this file.")
+    filename = _grid_out_property('filename', 'Name of this file.')
+    name = _grid_out_property('filename', 'Alias for `filename`.')
+    content_type = _grid_out_property('contentType', 'Mime-type for this file.')
+    length = _grid_out_property('length', 'Length (in bytes) of this file.')
+    chunk_size = _grid_out_property('chunkSize', 'Chunk size for this file.')
+    upload_date = _grid_out_property('uploadDate',
+                                     'Date that this file was first uploaded.')
+    aliases = _grid_out_property('aliases', 'List of aliases for this file.')
+    metadata = _grid_out_property('metadata', 'Metadata attached to this file.')
+    md5 = _grid_out_property('md5', 'MD5 of the contents of this file '
+                             '(generated on the server).')
+
+    async def _ensure_file(self):
+        if not self._file:
+            self._file = await self.__files.find_one({'_id': self.__file_id})
+            if not self._file:
+                raise NoFile('no file in gridfs collection %r with _id %r' %
+                             (self.__files, self.__file_id))
+
+    def __getattr__(self, name):
+        if name in self._file:
+            return self._file[name]
+        raise AttributeError("GridOut object has no attribute '%s'" % name)
+
+    async def readchunk(self):
+        """Reads a chunk at a time. If the current position is within a
+        chunk the remainder of the chunk is returned.
+        """
+        received = len(self.__buffer)
+        chunk_data = EMPTY
+        chunk_size = int(self.chunk_size)
+
+        if received > 0:
+            chunk_data = self.__buffer
+        elif self.__position < int(self.length):
+            chunk_number = int((received + self.__position) / chunk_size)
+            chunk = await self.__chunks.find_one({'files_id': self._id,
+                                                 'n': chunk_number})
+            if not chunk:
+                raise CorruptGridFile('no chunk #%d' % chunk_number)
+
+            chunk_data = chunk['data'][self.__position % chunk_size:]
+
+            if not chunk_data:
+                raise CorruptGridFile('truncated chunk')
+
+        self.__position += len(chunk_data)
+        self.__buffer = EMPTY
+        return chunk_data
+
+    async def read(self, size=-1):
+        """Read at most `size` bytes from the file (less if there
+        isn't enough data).
+
+        The bytes are returned as an instance of :class:`str` (:class:`bytes`
+        in python 3). If `size` is negative or omitted all data is read.
+
+        :Parameters:
+          - `size` (optional): the number of bytes to read
+        """
+        await self._ensure_file()
+
+        if size == 0:
+            return EMPTY
+
+        remainder = int(self.length) - self.__position
+        if size < 0 or size > remainder:
+            size = remainder
+
+        received = 0
+        data = BytesIO()
+        while received < size:
+            chunk_data = await self.readchunk()
+            received += len(chunk_data)
+            data.write(chunk_data)
+
+        # Detect extra chunks.
+        max_chunk_n = math.ceil(self.length / float(self.chunk_size))
+        chunk = await self.__chunks.find_one({'files_id': self._id,
+                                             'n': {'$gte': max_chunk_n}})
+        # According to spec, ignore extra chunks if they are empty.
+        if chunk is not None and len(chunk['data']):
+            raise CorruptGridFile(
+                'Extra chunk found: expected %i chunks but found '
+                'chunk with n=%i' % (max_chunk_n, chunk['n']))
+
+        self.__position -= received - size
+
+        # Return 'size' bytes and store the rest.
+        data.seek(size)
+        self.__buffer = data.read()
+        data.seek(0)
+        return data.read(size)
+
+    def readline(self, size=-1):
+        """Read one line or up to `size` bytes from the file.
+
+        :Parameters:
+         - `size` (optional): the maximum number of bytes to read
+        """
+        if size == 0:
+            return b''
+
+        remainder = int(self.length) - self.__position
+        if size < 0 or size > remainder:
+            size = remainder
+
+        received = 0
+        data = StringIO()
+        while received < size:
+            chunk_data = self.readchunk()
+            pos = chunk_data.find(NEWLN, 0, size)
+            if pos != -1:
+                size = received + pos + 1
+
+            received += len(chunk_data)
+            data.write(chunk_data)
+            if pos != -1:
+                break
+
+        self.__position -= received - size
+
+        # Return 'size' bytes and store the rest.
+        data.seek(size)
+        self.__buffer = data.read()
+        data.seek(0)
+        return data.read(size)
+
+    def tell(self):
+        """Return the current position of this file.
+        """
+        return self.__position
+
+    def seek(self, pos, whence=SEEK_SET):
+        """Set the current position of this file.
+
+        :Parameters:
+         - `pos`: the position (or offset if using relative
+           positioning) to seek to
+         - `whence` (optional): where to seek
+           from. :attr:`os.SEEK_SET` (``0``) for absolute file
+           positioning, :attr:`os.SEEK_CUR` (``1``) to seek relative
+           to the current position, :attr:`os.SEEK_END` (``2``) to
+           seek relative to the file's end.
+        """
+        if whence == SEEK_SET:
+            new_pos = pos
+        elif whence == SEEK_CUR:
+            new_pos = self.__position + pos
+        elif whence == SEEK_END:
+            new_pos = int(self.length) + pos
+        else:
+            raise IOError(22, 'Invalid value for `whence`')
+
+        if new_pos < 0:
+            raise IOError(22, 'Invalid value for `pos` - must be positive')
+
+        self.__position = new_pos
+        self.__buffer = EMPTY
+
+    def __iter__(self):
+        """Return an iterator over all of this file's data.
+
+        The iterator will return chunk-sized instances of
+        :class:`str` (:class:`bytes` in python 3). This can be
+        useful when serving files using a webserver that handles
+        such an iterator efficiently.
+        """
+        return GridOutIterator(self, self.__chunks)
+
+    def close(self):
+        """Make GridOut more generically file-like."""
+        pass
+
+    def __enter__(self):
+        """Makes it possible to use :class:`GridOut` files
+        with the context manager protocol.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Makes it possible to use :class:`GridOut` files
+        with the context manager protocol.
+        """
+        return False
+
+
+class GridOutIterator(object):
+    def __init__(self, grid_out, chunks):
+        self.__id = grid_out._id
+        self.__chunks = chunks
+        self.__current_chunk = 0
+        self.__max_chunk = math.ceil(float(grid_out.length) /
+                                     grid_out.chunk_size)
+
+    def __iter__(self):
+        return self
+
+    async def next(self):
+        if self.__current_chunk >= self.__max_chunk:
+            raise StopIteration
+        chunk = await self.__chunks.find_one({'files_id': self.__id,
+                                              'n': self.__current_chunk})
+        if not chunk:
+            raise CorruptGridFile('no chunk #%d' % self.__current_chunk)
+        self.__current_chunk += 1
+        return bytes(chunk['data'])
+
+    __next__ = next

--- a/aiomongo/gridfs.py
+++ b/aiomongo/gridfs.py
@@ -18,7 +18,7 @@ class GridFS:
         self.__files = self.__collection.files
         self.__chunks = self.__collection.chunks
 
-    def new_file(self, **kwargs):
+    async def new_file(self, **kwargs):
         """Create a new file in GridFS.
 
         Returns a new :class:`~gridfs.grid_file.GridIn` instance to
@@ -170,3 +170,40 @@ class GridFS:
         return [
             name for name in await self.__files.distinct('filename')
             if name is not None]
+
+    async def exists(self, document_or_id=None, **kwargs):
+        """Check if a file exists in this instance of :class:`GridFS`.
+
+        The file to check for can be specified by the value of its
+        ``_id`` key, or by passing in a query document. A query
+        document can be passed in as dictionary, or by using keyword
+        arguments. Thus, the following three calls are equivalent:
+
+        >>> fs.exists(file_id)
+        >>> fs.exists({'_id': file_id})
+        >>> fs.exists(_id=file_id)
+
+        As are the following two calls:
+
+        >>> fs.exists({'filename': 'mike.txt'})
+        >>> fs.exists(filename='mike.txt')
+
+        And the following two:
+
+        >>> fs.exists({'foo': {'$gt': 12}})
+        >>> fs.exists(foo={'$gt': 12})
+
+        Returns ``True`` if a matching file exists, ``False``
+        otherwise. Calls to :meth:`exists` will not automatically
+        create appropriate indexes; application developers should be
+        sure to create indexes if needed and as appropriate.
+
+        :Parameters:
+          - `document_or_id` (optional): query document, or _id of the
+            document to check for
+          - `**kwargs` (optional): keyword arguments are used as a
+            query document, if they're present.
+        """
+        if kwargs:
+            return await self.__files.find_one(kwargs, ['_id']) is not None
+        return await self.__files.find_one(document_or_id, ['_id']) is not None

--- a/aiomongo/gridfs.py
+++ b/aiomongo/gridfs.py
@@ -1,0 +1,158 @@
+from typing import Any, BinaryIO, List, Union
+
+from pymongo import ASCENDING, DESCENDING
+from pymongo.errors import ConfigurationError
+
+from .grid_file import GridIn, GridOut
+
+
+class GridFS:
+    def __init__(self, database: 'aiomongo.Database', collection: str = 'fs'):
+        if not database.write_concern.acknowledged:
+            raise ConfigurationError('database must use '
+                                     'acknowledged write_concern')
+
+        self.__database = database
+        self.__collection = database[collection]
+        self.__files = self.__collection.files
+        self.__chunks = self.__collection.chunks
+
+    async def put(self, data: Union[bytes, BinaryIO], **kwargs) -> GridIn:
+        """Put data in GridFS as a new file.
+
+        Equivalent to doing::
+
+          try:
+              f = new_file(**kwargs)
+              f.write(data)
+          finally:
+              f.close()
+
+        `data` can be either an instance of :class:`str` (:class:`bytes`
+        in python 3) or a file-like object providing a :meth:`read` method.
+        If an `encoding` keyword argument is passed, `data` can also be a
+        :class:`unicode` (:class:`str` in python 3) instance, which will
+        be encoded as `encoding` before being written. Any keyword arguments
+        will be passed through to the created file - see
+        :meth:`~gridfs.grid_file.GridIn` for possible arguments. Returns the
+        ``"_id"`` of the created file.
+
+        If the ``"_id"`` of the file is manually specified, it must
+        not already exist in GridFS. Otherwise
+        :class:`~gridfs.errors.FileExists` is raised.
+
+        :Parameters:
+          - `data`: data to be written as a file.
+          - `**kwargs` (optional): keyword arguments for file creation
+        """
+        grid_file = GridIn(self.__collection, **kwargs)
+        try:
+            grid_file.write(data)
+        finally:
+            await grid_file.close()
+
+        return grid_file._id
+
+    async def get(self, file_id: Any) -> GridOut:
+        """Get a file from GridFS by ``"_id"``.
+
+        Returns an instance of :class:`~gridfs.grid_file.GridOut`,
+        which provides a file-like interface for reading.
+
+        :Parameters:
+          - `file_id`: ``"_id"`` of the file to get
+        """
+        gout = GridOut(self.__collection, file_id)
+
+        # Raise NoFile now, instead of on first attribute access.
+        await gout._ensure_file()
+        return gout
+
+    async def get_version(self, filename=None, version=-1, **kwargs):
+        """Get a file from GridFS by ``"filename"`` or metadata fields.
+
+        Returns a version of the file in GridFS whose filename matches
+        `filename` and whose metadata fields match the supplied keyword
+        arguments, as an instance of :class:`~gridfs.grid_file.GridOut`.
+
+        Version numbering is a convenience atop the GridFS API provided
+        by MongoDB. If more than one file matches the query (either by
+        `filename` alone, by metadata fields, or by a combination of
+        both), then version ``-1`` will be the most recently uploaded
+        matching file, ``-2`` the second most recently
+        uploaded, etc. Version ``0`` will be the first version
+        uploaded, ``1`` the second version, etc. So if three versions
+        have been uploaded, then version ``0`` is the same as version
+        ``-3``, version ``1`` is the same as version ``-2``, and
+        version ``2`` is the same as version ``-1``.
+
+        Raises :class:`~gridfs.errors.NoFile` if no such version of
+        that file exists.
+
+        :Parameters:
+          - `filename`: ``"filename"`` of the file to get, or `None`
+          - `version` (optional): version of the file to get (defaults
+            to -1, the most recent version uploaded)
+          - `**kwargs` (optional): find files by custom metadata.
+
+        .. versionchanged:: 3.1
+           ``get_version`` no longer ensures indexes.
+        """
+        query = kwargs
+        if filename is not None:
+            query['filename'] = filename
+
+        cursor = self.__files.find(query)
+        if version < 0:
+            skip = abs(version) - 1
+            cursor.limit(-1).skip(skip).sort('uploadDate', DESCENDING)
+        else:
+            cursor.limit(-1).skip(version).sort('uploadDate', ASCENDING)
+        try:
+            grid_file = next(cursor)
+            return GridOut(self.__collection, file_document=grid_file)
+        except StopIteration:
+            raise NoFile('no version %d for filename %r' % (version, filename))
+
+    async def get_last_version(self, filename=None, **kwargs):
+        """Get the most recent version of a file in GridFS by ``"filename"``
+        or metadata fields.
+
+        Equivalent to calling :meth:`get_version` with the default
+        `version` (``-1``).
+
+        :Parameters:
+          - `filename`: ``"filename"`` of the file to get, or `None`
+          - `**kwargs` (optional): find files by custom metadata.
+        """
+        return self.get_version(filename=filename, **kwargs)
+
+    async def delete(self, file_id: Any) -> None:
+        """Delete a file from GridFS by ``"_id"``.
+
+        Deletes all data belonging to the file with ``"_id"``:
+        `file_id`.
+
+        .. warning:: Any processes/threads reading from the file while
+           this method is executing will likely see an invalid/corrupt
+           file. Care should be taken to avoid concurrent reads to a file
+           while it is being deleted.
+
+        .. note:: Deletes of non-existent files are considered successful
+           since the end result is the same: no file with that _id remains.
+
+        :Parameters:
+          - `file_id`: ``"_id"`` of the file to delete
+        """
+        await self.__files.delete_one({'_id': file_id})
+        await self.__chunks.delete_many({'files_id': file_id})
+
+    async def list(self) -> List:
+        """List the names of all files stored in this instance of
+        :class:`GridFS`.
+        """
+        # With an index, distinct includes documents with no filename
+        # as None.
+        return [
+            name for name in await self.__files.distinct('filename')
+            if name is not None]

--- a/aiomongo/gridfs.py
+++ b/aiomongo/gridfs.py
@@ -36,7 +36,7 @@ class GridFS:
         # the (files_id, n) index when needed.
         return GridIn(self.__collection, **kwargs)
 
-    async def put(self, data: Union[bytes, BinaryIO], **kwargs) -> GridIn:
+    async def put(self, data: Union[bytes, str, BinaryIO], **kwargs) -> GridIn:
         """Put data in GridFS as a new file.
 
         Equivalent to doing::

--- a/aiomongo/gridfs.py
+++ b/aiomongo/gridfs.py
@@ -87,7 +87,7 @@ class GridFS:
         await gout._ensure_file()
         return gout
 
-    async def get_version(self, filename=None, version=-1, **kwargs):
+    async def get_version(self, filename=None, version=-1, **kwargs) -> GridOut:
         """Get a file from GridFS by ``"filename"`` or metadata fields.
 
         Returns a version of the file in GridFS whose filename matches
@@ -128,7 +128,7 @@ class GridFS:
             return GridOut(self.__collection, file_document=grid_file)
         raise NoFile('no version %d for filename %r' % (version, filename))
 
-    async def get_last_version(self, filename=None, **kwargs):
+    async def get_last_version(self, filename=None, **kwargs) -> GridOut:
         """Get the most recent version of a file in GridFS by ``"filename"``
         or metadata fields.
 

--- a/aiomongo/gridfs.py
+++ b/aiomongo/gridfs.py
@@ -47,7 +47,7 @@ class GridFS:
         """
         grid_file = GridIn(self.__collection, **kwargs)
         try:
-            grid_file.write(data)
+            await grid_file.write(data)
         finally:
             await grid_file.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,13 @@ def test_db(event_loop, mongo):
 
 
 @pytest.fixture(scope='function')
+def test_fs(event_loop, test_db):
+    event_loop.run_until_complete(test_db.drop_collection('fs.files'))
+    event_loop.run_until_complete(test_db.drop_collection('fs.chunks'))
+    return aiomongo.GridFS(test_db)
+
+
+@pytest.fixture(scope='function')
 def mongo_version(event_loop, mongo):
     server_info = event_loop.run_until_complete(
         mongo.server_info()
@@ -36,5 +43,3 @@ def mongo_version(event_loop, mongo):
     if 'versionArray' in server_info:
         return Version.from_version_array(server_info['versionArray'])
     return Version.from_string(server_info['version'])
-
-

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -494,7 +494,7 @@ class TestCursor:
 
         if mongo_version.at_least(3, 3, 2):
             assert 0 == await collection.find().hint('x_1').count()
-            assert 0 == await collection.find().hint([('x' == 1)]).count()
+            assert 0 == await collection.find().hint([('x', 1)]).count()
         else:
             assert 2 == await collection.find().hint('x_1').count()
             assert 2 == await collection.find().hint([('x', 1)]).count()

--- a/tests/test_gridfs.py
+++ b/tests/test_gridfs.py
@@ -299,3 +299,13 @@ class TestGridFs:
         assert b'test1' == await (await test_fs.find_one({'filename': 'file1'})).read()
 
         assert 'data' == (await test_fs.find_one(id2)).meta
+
+    @pytest.mark.asyncio
+    async def test_grid_in_non_int_chunksize(self, test_db, test_fs):
+        # Lua, and perhaps other buggy GridFS clients, store size as a float.
+        data = b'data'
+        await test_fs.put(data, filename='f')
+        await test_db.fs.files.update_one({'filename': 'f'},
+                                          {'$set': {'chunkSize': 100.0}})
+
+        assert data == await (await test_fs.get_version('f')).read()

--- a/tests/test_gridfs.py
+++ b/tests/test_gridfs.py
@@ -25,6 +25,17 @@ class TestGridFs:
         assert b'hello world' == await (await test_fs.get('foo')).read()
 
     @pytest.mark.asyncio
+    async def test_multi_chunk_delete(self, test_db, test_fs):
+        assert 0 == await test_db.fs.files.count()
+        assert 0 == await test_db.fs.chunks.count()
+        oid = await test_fs.put(b'hello', chunkSize=1)
+        assert 1 == await test_db.fs.files.count()
+        assert 5 == await test_db.fs.chunks.count()
+        await test_fs.delete(oid)
+        assert 0 == await test_db.fs.files.count()
+        assert 0 == await test_db.fs.chunks.count()
+
+    @pytest.mark.asyncio
     async def test_list(self, test_fs):
         assert [] == await test_fs.list()
         await test_fs.put(b'hello world')

--- a/tests/test_gridfs.py
+++ b/tests/test_gridfs.py
@@ -232,3 +232,16 @@ class TestGridFs:
         assert not await test_fs.exists({'foo': 13})
         assert not await test_fs.exists(foo={'$gt': 12})
         assert not await test_fs.exists({'foo': {'$gt': 12}})
+
+    @pytest.mark.asyncio
+    async def test_put_unicode(self, test_fs):
+        with pytest.raises(TypeError):
+            await test_fs.put(u'hello')
+
+        oid = await test_fs.put(u'hello', encoding='utf-8')
+        assert b'hello' == await (await test_fs.get(oid)).read()
+        assert 'utf-8' == (await test_fs.get(oid)).encoding
+
+        oid = await test_fs.put(u'aé', encoding='iso-8859-1')
+        assert u'aé'.encode('iso-8859-1') == await (await test_fs.get(oid)).read()
+        assert 'iso-8859-1' == (await test_fs.get(oid)).encoding

--- a/tests/test_gridfs.py
+++ b/tests/test_gridfs.py
@@ -1,5 +1,6 @@
 import datetime
 import pytest
+from io import BytesIO
 
 from bson.binary import Binary
 from gridfs.errors import CorruptGridFile, NoFile
@@ -185,3 +186,9 @@ class TestGridFs:
         await test_fs.delete(one)
         await test_fs.delete(two)
         await test_fs.delete(three)
+
+    @pytest.mark.asyncio
+    async def test_put_filelike(self, test_db, test_fs):
+        oid = await test_fs.put(BytesIO(b'hello world'), chunk_size=1)
+        assert 11 == await test_db.fs.chunks.count()
+        assert b'hello world' == await (await test_fs.get(oid)).read()

--- a/tests/test_gridfs.py
+++ b/tests/test_gridfs.py
@@ -1,0 +1,56 @@
+import datetime
+import pytest
+from gridfs.errors import NoFile
+
+
+class TestGridFs:
+
+    @pytest.mark.asyncio
+    async def test_basic(self, test_db, test_fs):
+        oid = await test_fs.put(b'hello world')
+        assert b'hello world' == await (await test_fs.get(oid)).read()
+        assert 1 == await test_db.fs.files.count()
+        assert 1 == await test_db.fs.chunks.count()
+
+        await test_fs.delete(oid)
+        with pytest.raises(NoFile):
+            await test_fs.get(oid)
+        assert 0 == await test_db.fs.files.count()
+        assert 0 == await test_db.fs.chunks.count()
+
+        with pytest.raises(NoFile):
+            await test_fs.get('foo')
+        oid = await test_fs.put(b'hello world', _id='foo')
+        assert 'foo' == oid
+        assert b'hello world' == await (await test_fs.get('foo')).read()
+
+    @pytest.mark.asyncio
+    async def test_list(self, test_fs):
+        assert [] == await test_fs.list()
+        await test_fs.put(b'hello world')
+        assert [] == await test_fs.list()
+
+        # PYTHON-598: in server versions before 2.5.x, creating an index on
+        # filename, uploadDate causes list() to include None.
+        await test_fs.get_last_version()
+        assert [] == await test_fs.list()
+
+        await test_fs.put(b'', filename='mike')
+        await test_fs.put(b'foo', filename='test')
+        await test_fs.put(b'', filename='hello world')
+
+        assert {'mike', 'test', 'hello world'} == set(await test_fs.list())
+
+    @pytest.mark.asyncio
+    async def test_empty_file(self, test_db, test_fs):
+        oid = await test_fs.put(b'')
+        assert b'' == await (await test_fs.get(oid)).read()
+        assert 1 == await test_db.fs.files.count()
+        assert 0 == await test_db.fs.chunks.count()
+
+        raw = await test_db.fs.files.find_one()
+        assert 0 == raw['length']
+        assert oid == raw['_id']
+        assert isinstance(raw['uploadDate'], datetime.datetime)
+        assert 255 * 1024 == raw['chunkSize']
+        assert isinstance(raw['md5'], str)


### PR DESCRIPTION
This PR ports GridFS from pymongo 3.3 branch.

Main difference: Not allowed to set property of GridIn after close. This was allowed in pymongo with the behavior of updating the database, but impossible to implement in aiomongo due to no async properties.

Omitted tests:
* test_alt_collection
* test_threaded_reads
* test_threaded_writes
* test_gridfs_lazy_connect
* test_unacknowledged